### PR TITLE
chore: lint check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Code Linting Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint-check:
+    runs-on: ubuntu-latest
+    name: Check PR's Linting
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install deps (with cache)
+        uses: bahmutov/npm-install@v1.7.10
+        with:
+          working-directory: './'
+          useLockFile: false
+
+      - name: eslint check
+        run: npm run lint

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ export default function App() {
       <a
         href="https://github.com/akulsr0/github-action-examples"
         target="_blank"
-        rel="noreferrer"
       >
         [github]
       </a>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ export default function App() {
       <a
         href="https://github.com/akulsr0/github-action-examples"
         target="_blank"
+        rel="noreferrer"
       >
         [github]
       </a>


### PR DESCRIPTION
- Have removed `rel='noreferrer'` from anchor tag having `target='_blank'` in `App.tsx`, to get linting error and fail the github action. [5f7cc85](https://github.com/akulsr0/github-action-examples/pull/17/commits/5f7cc858ed36efb11a3210384b45590a1eec021a)
- Fixed linting error in [4b5163a](https://github.com/akulsr0/github-action-examples/pull/17/commits/4b5163a8275df1aed1dbe0f90c317f3d5bac8f5f)
